### PR TITLE
DBA-15: Fix empty queries in sql script

### DIFF
--- a/src/Service/Extractor/PostgresDataExtractor.php
+++ b/src/Service/Extractor/PostgresDataExtractor.php
@@ -183,7 +183,7 @@ class PostgresDataExtractor implements
 
             // Split the insert query into parts to make it to have
             // X rows max to optimize performance on DB import.
-            if (0 === (++$numRows % $maxInsertRows)) {
+            if (0 === (++$numRows % $maxInsertRows) && $sql !== $insertSql) {
                 $sql = $this->removeTrailingComma($sql) . ';' . PHP_EOL;
 
                 // Export rows to file right away if needed.


### PR DESCRIPTION
## Overview
There was a bug found while exporting entities with `insert_rows_max: 1` setting - some insert queries were empty (there was no values).

Now it's fixed.

## Before
```
INSERT INTO field_data_field_magic VALUES;
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6523,58684193,'und',0,139725,null);
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6524,58683687,'und',0,141342,null);
INSERT INTO field_data_field_magic VALUES;
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6525,58683652,'und',0,140683,null);
```

## After
```
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6523,58684193,'und',0,139725,null);
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6524,58683687,'und',0,141342,null);
INSERT INTO field_data_field_magic VALUES
('node','fantastic',0,6525,58683652,'und',0,140683,null);
```

## Technical details
There was an empty queries check on final write to the file (line 210), but same check was missing for other dump file updates (line 186). So it was an easy fix.